### PR TITLE
[STORE] 가게 도메인 기능 추가 및 버그 수정 #5

### DIFF
--- a/src/main/java/com/sparta/deliveryi/store/domain/Category.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Category.java
@@ -1,7 +1,24 @@
 package com.sparta.deliveryi.store.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.*;
 
+@ToString
+@Getter
+@EqualsAndHashCode
 @Embeddable
-public record Category(String type) {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Column(name = "store_category", nullable = false)
+    private String name;
+
+    private Category(String name) {
+        this.name = name;
+    }
+
+    public static Category of(String name) {
+        return new Category(name);
+    }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/Owner.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Owner.java
@@ -1,9 +1,26 @@
 package com.sparta.deliveryi.store.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.*;
 
 import java.util.UUID;
 
+@ToString
+@Getter
+@EqualsAndHashCode
 @Embeddable
-public record Owner(UUID id) {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Owner {
+
+    @Column(name = "user_id", nullable = false)
+    private UUID id;
+
+    private Owner(UUID id) {
+        this.id = id;
+    }
+
+    public static Owner of(UUID id) {
+        return new Owner(id);
+    }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/Rating.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Rating.java
@@ -2,7 +2,13 @@ package com.sparta.deliveryi.store.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = false)
 @Embeddable
 public class Rating {
     @Column(name = "rating", nullable = false)
@@ -12,8 +18,12 @@ public class Rating {
         this.score = 0.0f;
     }
 
-    public Rating(Float score) {
+    private Rating(Float score) {
         this.score = score;
+    }
+
+    public static Rating of(Float score) {
+        return new Rating(score);
     }
 
     public String score() {

--- a/src/main/java/com/sparta/deliveryi/store/domain/Rating.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Rating.java
@@ -1,10 +1,11 @@
 package com.sparta.deliveryi.store.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class Rating {
-
+    @Column(name = "rating", nullable = false)
     private final Float score;
 
     public Rating() {

--- a/src/main/java/com/sparta/deliveryi/store/domain/Store.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Store.java
@@ -21,15 +21,12 @@ public class Store extends AbstractEntity {
 
     @EmbeddedId
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "store_id")
     private StoreId id;
 
     @Embedded
-    @Column(name = "user_id", nullable = false)
     private Owner owner;
 
     @Embedded
-    @Column(name = "store_category", nullable = false)
     private Category category;
 
     @Column(name = "store_name", nullable = false)
@@ -48,7 +45,6 @@ public class Store extends AbstractEntity {
     private String notice;
 
     @Embedded
-    @Column(nullable = false)
     private Rating rating;
 
     @Convert(converter = AvailableAddressConverter.class)
@@ -65,8 +61,8 @@ public class Store extends AbstractEntity {
     public static Store registerRequest(StoreRegisterRequest registerRequest) {
         Store store = new Store();
 
-        store.owner = new Owner(registerRequest.ownerId());
-        store.category = new Category(registerRequest.category());
+        store.owner = Owner.of(registerRequest.ownerId());
+        store.category = Category.of(registerRequest.category());
         store.name = registerRequest.name();
         store.description = registerRequest.description();
         store.address = registerRequest.address();

--- a/src/main/java/com/sparta/deliveryi/store/domain/Store.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Store.java
@@ -7,8 +7,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.util.Assert;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.springframework.util.Assert.*;
 
@@ -100,5 +102,19 @@ public class Store extends AbstractEntity {
         }
 
         this.status = StoreStatus.READY;
+    }
+
+    public void updateInfo(StoreInfoUpdateRequest updateRequest) {
+        state(this.status != StoreStatus.PENDING, "등록 대기 상태에서는 가게 정보를 수정할 수 없습니다.");
+
+        this.name = Objects.requireNonNull(updateRequest.name());
+        this.category = Category.of(Objects.requireNonNull(updateRequest.category()));
+        this.description = Objects.requireNonNull(updateRequest.description());
+        this.address = Objects.requireNonNull(updateRequest.address());
+        this.phone = Objects.requireNonNull(updateRequest.phone());
+        this.notice = updateRequest.notice();
+        this.availableAddress = updateRequest.availableAddress();
+        this.operationHours = updateRequest.operationHours();
+        this.closedDays = updateRequest.closedDays();
     }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/Store.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Store.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.springframework.util.Assert.*;
+import static org.springframework.util.Assert.state;
 
 @Table(name = "p_store")
 @Entity
@@ -22,7 +22,6 @@ import static org.springframework.util.Assert.*;
 public class Store extends AbstractEntity {
 
     @EmbeddedId
-    @GeneratedValue(strategy = GenerationType.UUID)
     private StoreId id;
 
     @Embedded
@@ -63,6 +62,7 @@ public class Store extends AbstractEntity {
     public static Store registerRequest(StoreRegisterRequest registerRequest) {
         Store store = new Store();
 
+        store.id = StoreId.generateId();
         store.owner = Owner.of(registerRequest.ownerId());
         store.category = Category.of(registerRequest.category());
         store.name = registerRequest.name();

--- a/src/main/java/com/sparta/deliveryi/store/domain/Store.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Store.java
@@ -7,10 +7,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.util.Assert;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import static org.springframework.util.Assert.*;
 
@@ -116,5 +116,11 @@ public class Store extends AbstractEntity {
         this.availableAddress = updateRequest.availableAddress();
         this.operationHours = updateRequest.operationHours();
         this.closedDays = updateRequest.closedDays();
+    }
+
+    public void transferOwnership(UUID ownerId) {
+        state(this.status != StoreStatus.PENDING, "등록 대기 상태에서는 인수인계할 수 없습니다.");
+
+        owner = Owner.of(Objects.requireNonNull(ownerId));
     }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/Store.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Store.java
@@ -123,4 +123,10 @@ public class Store extends AbstractEntity {
 
         owner = Owner.of(Objects.requireNonNull(ownerId));
     }
+
+    public void updateRating(Rating rating) {
+        state(this.status != StoreStatus.PENDING, "등록 대기 상태에서는 평점을 갱신할 수 없습니다.");
+
+        this.rating = Objects.requireNonNull(rating);
+    }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreId.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreId.java
@@ -1,9 +1,17 @@
 package com.sparta.deliveryi.store.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.*;
 
 import java.util.UUID;
 
+@ToString
+@Getter
+@EqualsAndHashCode
 @Embeddable
-public record StoreId(UUID id) {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreId {
+    @Column(name = "store_id")
+    private UUID id;
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreId.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreId.java
@@ -6,12 +6,28 @@ import lombok.*;
 
 import java.util.UUID;
 
-@ToString
 @Getter
 @EqualsAndHashCode
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreId {
+
     @Column(name = "store_id")
     private UUID id;
+
+    private StoreId(UUID id) {
+        this.id = id;
+    }
+
+    public static StoreId generateId() {
+        return of(UUID.randomUUID());
+    }
+
+    public static StoreId of(UUID id) {
+        return new StoreId(id);
+    }
+
+    public String toString(){
+        return id.toString();
+    }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreInfoUpdateRequest.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreInfoUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.sparta.deliveryi.store.domain;
+
+import java.util.List;
+
+public record StoreInfoUpdateRequest(
+        String name,
+        String category,
+        String description,
+        String address,
+        String phone,
+        String notice,
+        List<String> availableAddress,
+        String operationHours,
+        String closedDays
+) {
+}

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreRegisterRequest.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreRegisterRequest.java
@@ -1,13 +1,16 @@
 package com.sparta.deliveryi.store.domain;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.util.UUID;
 
 public record StoreRegisterRequest(
-        UUID ownerId,
-        String category,
-        String name,
-        String description,
-        String address,
-        String phone
+        @NotNull UUID ownerId,
+        @NotNull String category,
+        @NotNull String name,
+        @NotNull String description,
+        @NotNull String address,
+        @NotNull @Size(max = 20) String phone
 ) {
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreRepository.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.deliveryi.store.domain;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface StoreRepository extends Repository<Store, StoreId> {
+    Store save(Store store);
+
+    Optional<Store> findById(StoreId storeId);
+}

--- a/src/main/java/com/sparta/deliveryi/store/domain/service/StoreFinder.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/service/StoreFinder.java
@@ -1,0 +1,8 @@
+package com.sparta.deliveryi.store.domain.service;
+
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreId;
+
+public interface StoreFinder {
+    Store find(StoreId storeId);
+}

--- a/src/main/java/com/sparta/deliveryi/store/domain/service/StoreQueryService.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/service/StoreQueryService.java
@@ -1,0 +1,23 @@
+package com.sparta.deliveryi.store.domain.service;
+
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreId;
+import com.sparta.deliveryi.store.domain.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StoreQueryService implements StoreFinder {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public Store find(StoreId storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("가게 정보를 찾을 수 없습니다. id: " + storeId));
+    }
+
+}

--- a/src/main/java/com/sparta/deliveryi/store/domain/service/StoreRegister.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/service/StoreRegister.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryi.store.domain.service;
+
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
+import jakarta.validation.Valid;
+
+public interface StoreRegister {
+    Store register(@Valid StoreRegisterRequest registerRequest);
+}

--- a/src/main/java/com/sparta/deliveryi/store/domain/service/StoreRegisterService.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/service/StoreRegisterService.java
@@ -1,0 +1,25 @@
+package com.sparta.deliveryi.store.domain.service;
+
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
+import com.sparta.deliveryi.store.domain.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StoreRegisterService implements StoreRegister {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public Store register(StoreRegisterRequest registerRequest) {
+        Store store = Store.registerRequest(registerRequest);
+
+        storeRepository.save(store);
+
+        return store;
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/store/StoreFixture.java
+++ b/src/test/java/com/sparta/deliveryi/store/StoreFixture.java
@@ -1,0 +1,43 @@
+package com.sparta.deliveryi.store;
+
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreInfoUpdateRequest;
+import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
+
+import java.util.List;
+import java.util.UUID;
+
+public class StoreFixture {
+
+    public static StoreInfoUpdateRequest createStoreInfoUpdateRequest() {
+
+        return new StoreInfoUpdateRequest(
+                "홍길동 분식",
+                "SNACK_FOOD",
+                "분식 가게입니다.",
+                "서울시 강남구 테스트로 13",
+                "02-1234-5678",
+                "매주 일요일 휴무입니다.",
+                List.of("강남구", "관악구", "강동구"),
+                "06:00 ~ 22:00",
+                "매주 일요일"
+        );
+    }
+
+    public static Store createStore() {
+        StoreRegisterRequest registerRequest = createStoreRegisterRequest();
+
+        return Store.registerRequest(registerRequest);
+    }
+
+    public static StoreRegisterRequest createStoreRegisterRequest() {
+        return new StoreRegisterRequest(
+                UUID.randomUUID(),
+                "KOREAN",
+                "홍길동",
+                "한식 가게입니다.",
+                "서울시 강남구 테스트로 12",
+                "02-1234-1234"
+        );
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StoreTest {
 
@@ -142,6 +143,30 @@ class StoreTest {
 
         assertThatThrownBy(() -> store.updateInfo(updateRequest))
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void transferOwnership() {
+        store.acceptRegisterRequest();
+        UUID ownerId = UUID.randomUUID();
+
+        store.transferOwnership(ownerId);
+
+        assertThat(store.getOwner()).isEqualTo(Owner.of(ownerId));
+    }
+
+    @Test
+    void transferOwnerShipIfPendingStatus() {
+        assertThatThrownBy(() -> store.transferOwnership(null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void transferOwnerShipIfNullId() {
+        store.acceptRegisterRequest();
+
+        assertThatThrownBy(() -> store.transferOwnership(null))
+            .isInstanceOf(NullPointerException.class);
     }
 
     private static StoreInfoUpdateRequest createStoreInfoUpdateRequest() {

--- a/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
@@ -21,7 +21,7 @@ class StoreTest {
 
     @Test
     void registerRequest() {
-        assertThat(store.getCategory()).isEqualTo(new Category("KOREAN"));
+        assertThat(store.getCategory()).isEqualTo(Category.of("KOREAN"));
         assertThat(store.getName()).isEqualTo("홍길동");
         assertThat(store.getDescription()).isEqualTo("한식 가게입니다.");
         assertThat(store.getAddress()).isEqualTo("서울시 강남구 테스트로 12");

--- a/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
@@ -4,9 +4,12 @@ import com.sparta.deliveryi.TestMessageResolverInitializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StoreTest {
@@ -95,6 +98,65 @@ class StoreTest {
 
         assertThatThrownBy(() -> store.close())
                 .isInstanceOf(StoreException.class);
+    }
+
+    @Test
+    void updateInfo() {
+        StoreInfoUpdateRequest updateRequest = createStoreInfoUpdateRequest();
+        store.acceptRegisterRequest();
+
+        store.updateInfo(updateRequest);
+
+        assertThat(store.getCategory()).isEqualTo(Category.of("SNACK_FOOD"));
+        assertThat(store.getName()).isEqualTo("홍길동 분식");
+        assertThat(store.getDescription()).isEqualTo("분식 가게입니다.");
+        assertThat(store.getAddress()).isEqualTo("서울시 강남구 테스트로 13");
+        assertThat(store.getPhone()).isEqualTo("02-1234-5678");
+        assertThat(store.getAvailableAddress()).contains("강남구", "관악구", "강동구");
+        assertThat(store.getOperationHours()).isEqualTo("06:00 ~ 22:00");
+        assertThat(store.getClosedDays()).isEqualTo("매주 일요일");
+    }
+
+    @Test
+    void updateInfoIfPendingStatus() {
+        StoreInfoUpdateRequest updateRequest = createStoreInfoUpdateRequest();
+
+        assertThatThrownBy(() -> store.updateInfo(updateRequest))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void updateInfoIfNullValue() {
+        StoreInfoUpdateRequest updateRequest = new StoreInfoUpdateRequest(
+                null,
+                "SNACK_FOOD",
+                "분식 가게입니다.",
+                "서울시 강남구 테스트로 13",
+                "02-1234-5678",
+                "매주 일요일 휴무입니다.",
+                List.of("강남구", "관악구", "강동구"),
+                "06:00 ~ 22:00",
+                "매주 일요일"
+        );
+        store.acceptRegisterRequest();
+
+        assertThatThrownBy(() -> store.updateInfo(updateRequest))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private static StoreInfoUpdateRequest createStoreInfoUpdateRequest() {
+        StoreInfoUpdateRequest updateRequest = new StoreInfoUpdateRequest(
+                "홍길동 분식",
+                "SNACK_FOOD",
+                "분식 가게입니다.",
+                "서울시 강남구 테스트로 13",
+                "02-1234-5678",
+                "매주 일요일 휴무입니다.",
+                List.of("강남구", "관악구", "강동구"),
+                "06:00 ~ 22:00",
+                "매주 일요일"
+        );
+        return updateRequest;
     }
 
     private static Store createStoreRegisterRequest() {

--- a/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
@@ -169,6 +169,29 @@ class StoreTest {
             .isInstanceOf(NullPointerException.class);
     }
 
+    @Test
+    void updateRating() {
+        store.acceptRegisterRequest();
+
+        store.updateRating(Rating.of(5.0f));
+
+        assertThat(store.getRating().score()).isEqualTo("5.0");
+    }
+
+    @Test
+    void updateRatingIfPendingStatus() {
+        assertThatThrownBy(() -> store.updateRating(Rating.of(5.0f)))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void updateRatingIfNullRating() {
+        store.acceptRegisterRequest();
+
+        assertThatThrownBy(() -> store.updateRating(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
     private static StoreInfoUpdateRequest createStoreInfoUpdateRequest() {
         StoreInfoUpdateRequest updateRequest = new StoreInfoUpdateRequest(
                 "홍길동 분식",

--- a/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/StoreTest.java
@@ -7,10 +7,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static com.sparta.deliveryi.store.StoreFixture.createStore;
+import static com.sparta.deliveryi.store.StoreFixture.createStoreInfoUpdateRequest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StoreTest {
@@ -19,7 +18,7 @@ class StoreTest {
 
     @BeforeEach
     void setUp() {
-        store = createStoreRegisterRequest();
+        store = createStore();
         TestMessageResolverInitializer.initializeFromResourceBundle();
     }
 
@@ -190,33 +189,5 @@ class StoreTest {
 
         assertThatThrownBy(() -> store.updateRating(null))
                 .isInstanceOf(NullPointerException.class);
-    }
-
-    private static StoreInfoUpdateRequest createStoreInfoUpdateRequest() {
-        StoreInfoUpdateRequest updateRequest = new StoreInfoUpdateRequest(
-                "홍길동 분식",
-                "SNACK_FOOD",
-                "분식 가게입니다.",
-                "서울시 강남구 테스트로 13",
-                "02-1234-5678",
-                "매주 일요일 휴무입니다.",
-                List.of("강남구", "관악구", "강동구"),
-                "06:00 ~ 22:00",
-                "매주 일요일"
-        );
-        return updateRequest;
-    }
-
-    private static Store createStoreRegisterRequest() {
-        StoreRegisterRequest registerRequest = new StoreRegisterRequest(
-                UUID.randomUUID(),
-                "KOREAN",
-                "홍길동",
-                "한식 가게입니다.",
-                "서울시 강남구 테스트로 12",
-                "02-1234-1234"
-        );
-
-        return Store.registerRequest(registerRequest);
     }
 }

--- a/src/test/java/com/sparta/deliveryi/store/domain/service/StoreRegisterTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/service/StoreRegisterTest.java
@@ -1,0 +1,32 @@
+package com.sparta.deliveryi.store.domain.service;
+
+import com.sparta.deliveryi.store.StoreFixture;
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class StoreRegisterTest {
+
+    @Autowired
+    private StoreRegister storeRegister;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void register() {
+        Store store = storeRegister.register(StoreFixture.createStoreRegisterRequest());
+
+        assertThat(store.getId()).isNotNull();
+        assertThat(store.getStatus()).isEqualTo(StoreStatus.PENDING);
+        assertThat(store.getRating().score()).isEqualTo("0.0");
+    }
+}


### PR DESCRIPTION
## 📝 요약 (Summary)
가게 도메인 기능 추가 및 버그 수정

## 🛠️ 작업 내용 (Details)
1. JPA 어노테이션 작성 위치로 인한 문제 수정
2. 가게 정보 수정, 인수인계, 평점 갱신 기능 추가
3. 가게 등록 및 단건 조회 도메인 서비스 추가

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [x] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [x] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)