### PR TITLE
[STORE] 가게 등록 요청 API 추가 #5

### DIFF
--- a/src/main/java/com/sparta/deliveryi/store/domain/Store.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/Store.java
@@ -129,4 +129,9 @@ public class Store extends AbstractEntity {
 
         this.rating = Objects.requireNonNull(rating);
     }
+
+    public void remove() {
+        super.delete();
+        this.status = StoreStatus.REMOVED;
+    }
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreId.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreId.java
@@ -2,7 +2,10 @@ package com.sparta.deliveryi.store.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 

--- a/src/main/java/com/sparta/deliveryi/store/domain/StoreStatus.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/StoreStatus.java
@@ -1,5 +1,5 @@
 package com.sparta.deliveryi.store.domain;
 
 public enum StoreStatus {
-    PENDING, REJECTED, READY, OPEN
+    PENDING, REJECTED, READY, OPEN, REMOVED
 }

--- a/src/main/java/com/sparta/deliveryi/store/domain/service/StoreRegisterService.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/service/StoreRegisterService.java
@@ -3,12 +3,14 @@ package com.sparta.deliveryi.store.domain.service;
 import com.sparta.deliveryi.store.domain.Store;
 import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
 import com.sparta.deliveryi.store.domain.StoreRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 @Service
 @Transactional
+@Validated
 @RequiredArgsConstructor
 public class StoreRegisterService implements StoreRegister {
 

--- a/src/main/java/com/sparta/deliveryi/store/presentation/webapi/StoreApi.java
+++ b/src/main/java/com/sparta/deliveryi/store/presentation/webapi/StoreApi.java
@@ -1,0 +1,27 @@
+package com.sparta.deliveryi.store.presentation.webapi;
+
+import com.sparta.deliveryi.global.presentation.dto.ApiResponse;
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
+import com.sparta.deliveryi.store.domain.service.StoreRegister;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StoreApi {
+
+    private final StoreRegister storeRegister;
+
+    @PostMapping("/v1/stores")
+    public ResponseEntity<ApiResponse<StoreRegisterResponse>> register(@RequestBody @Valid StoreRegisterRequest registerRequest) {
+        Store store = storeRegister.register(registerRequest);
+
+        return ResponseEntity.ok(ApiResponse.successWithDataOnly(StoreRegisterResponse.from(store)));
+    }
+
+}

--- a/src/main/java/com/sparta/deliveryi/store/presentation/webapi/StoreRegisterResponse.java
+++ b/src/main/java/com/sparta/deliveryi/store/presentation/webapi/StoreRegisterResponse.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryi.store.presentation.webapi;
+
+import com.sparta.deliveryi.store.domain.Store;
+
+public record StoreRegisterResponse(String storeId) {
+    public static StoreRegisterResponse from(Store store) {
+        return new StoreRegisterResponse(store.getId().toString());
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/AssertThatUtils.java
+++ b/src/test/java/com/sparta/deliveryi/AssertThatUtils.java
@@ -1,0 +1,17 @@
+package com.sparta.deliveryi;
+
+import org.assertj.core.api.AssertProvider;
+import org.assertj.core.api.Assertions;
+import org.springframework.test.json.JsonPathValueAssert;
+
+import java.util.function.Consumer;
+
+public class AssertThatUtils {
+    public static Consumer<AssertProvider<JsonPathValueAssert>> notNull() {
+        return value -> Assertions.assertThat(value).isNotNull();
+    }
+
+    public static Consumer<AssertProvider<JsonPathValueAssert>> isTrue() {
+        return value -> Assertions.assertThat(value).asBoolean().isTrue();
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/store/domain/service/StoreRegisterTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/domain/service/StoreRegisterTest.java
@@ -6,20 +6,13 @@ import com.sparta.deliveryi.store.domain.StoreStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-class StoreRegisterTest {
-
-    @Autowired
-    private StoreRegister storeRegister;
-
-    @Autowired
-    private EntityManager entityManager;
+record StoreRegisterTest(StoreRegister storeRegister, EntityManager entityManager) {
 
     @Test
     void register() {

--- a/src/test/java/com/sparta/deliveryi/store/presentation/webapi/StoreApiTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/presentation/webapi/StoreApiTest.java
@@ -1,0 +1,73 @@
+package com.sparta.deliveryi.store.presentation.webapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.deliveryi.store.StoreFixture;
+import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
+import com.sparta.deliveryi.store.domain.StoreRepository;
+import com.sparta.deliveryi.store.domain.service.StoreRegister;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.UnsupportedEncodingException;
+
+import static com.sparta.deliveryi.AssertThatUtils.isTrue;
+import static com.sparta.deliveryi.AssertThatUtils.notNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
+class StoreApiTest {
+    final MockMvcTester mvcTester;
+    final ObjectMapper objectMapper;
+    final StoreRepository storeRepository;
+
+    @Autowired
+    final StoreRegister storeRegister;
+
+    @Test
+    @WithMockUser
+    void register() throws JsonProcessingException, UnsupportedEncodingException {
+        StoreRegisterRequest request = StoreFixture.createStoreRegisterRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/stores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .exchange();
+
+        System.out.println(result.getResponse().getContentAsString());
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue())
+                .hasPathSatisfying("$.data", notNull());
+    }
+
+    @TestConfiguration
+    static class NoSecurityConfig {
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            return http.csrf(CsrfConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+    }
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+spring.test.constructor.autowire.mode=all


### PR DESCRIPTION
## 📝 요약 (Summary)
가게 등록 요청 API 추가

## 🛠️ 작업 내용 (Details)
1. 테스트 코드에서 생성자 주입 가능하도록 설정 추가 및 일부 테스트 코드 생성자 주입 적용 리팩터링
2. 가게 등록 서비스 도메인에 Validated 추가
3. 가게 등록 api 추가

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)