### PR TITLE
[USER] 회원 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/deliveryi/user/application/dto/AdminUserResponse.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/AdminUserResponse.java
@@ -1,0 +1,3 @@
+package com.sparta.deliveryi.user.application.dto;
+
+public record AdminUserResponse() {}

--- a/src/main/java/com/sparta/deliveryi/user/application/dto/AdminUserResponse.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/AdminUserResponse.java
@@ -1,3 +1,22 @@
 package com.sparta.deliveryi.user.application.dto;
 
-public record AdminUserResponse() {}
+import com.sparta.deliveryi.user.domain.UserRole;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record AdminUserResponse(
+        UUID userId,
+        String username,
+        String nickname,
+        UserRole role,
+        String currentAddress,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
+) {}

--- a/src/main/java/com/sparta/deliveryi/user/application/dto/MyInfoResponse.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/MyInfoResponse.java
@@ -1,0 +1,4 @@
+package com.sparta.deliveryi.user.application.dto;
+
+public class MyInfoResponse {
+}

--- a/src/main/java/com/sparta/deliveryi/user/application/dto/MyInfoResponse.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/MyInfoResponse.java
@@ -1,4 +1,19 @@
 package com.sparta.deliveryi.user.application.dto;
 
-public class MyInfoResponse {
-}
+import com.sparta.deliveryi.user.domain.UserRole;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record MyInfoResponse (
+        UUID userId,
+        String username,
+        String nickname,
+        UserRole role,
+        String userPhone,
+        String currentAddress,
+        LocalDateTime createdAt,
+        String createdBy
+) {}

--- a/src/main/java/com/sparta/deliveryi/user/application/dto/UserResponse.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/UserResponse.java
@@ -1,5 +1,17 @@
 package com.sparta.deliveryi.user.application.dto;
 
-public record UserResponse (
+import com.sparta.deliveryi.user.domain.UserRole;
+import lombok.Builder;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record UserResponse (
+    UUID userId,
+    String username,
+    String nickname,
+    UserRole role,
+    LocalDateTime createdAt,
+    String createdBy
 ){}

--- a/src/main/java/com/sparta/deliveryi/user/application/dto/UserResponse.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/UserResponse.java
@@ -1,0 +1,5 @@
+package com.sparta.deliveryi.user.application.dto;
+
+public record UserResponse (
+
+){}

--- a/src/main/java/com/sparta/deliveryi/user/application/dto/UserSearchRequest.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/dto/UserSearchRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryi.user.application.dto;
+
+import com.sparta.deliveryi.user.domain.UserRole;
+
+public record UserSearchRequest(
+        String username,
+        String nickname,
+        UserRole role
+) {}

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserQuery.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserQuery.java
@@ -3,13 +3,17 @@ package com.sparta.deliveryi.user.application.service;
 import com.sparta.deliveryi.user.application.dto.AdminUserResponse;
 import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
 import com.sparta.deliveryi.user.application.dto.UserResponse;
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface UserQuery {
-    MyInfoResponse getMyInfo(UUID id);
-    UserResponse getUserById(UUID id);
-    AdminUserResponse getUserForAdminById(UUID id);
-    List<AdminUserResponse> getUsersForAdminById();
+    MyInfoResponse getMyInfo(UUID keycloakId, UUID userId);
+    UserResponse getUserById(UUID userId);
+
+    AdminUserResponse getUserForAdminById(UUID keycloakId, UUID userId);
+
+    Page<AdminUserResponse> searchUsersForAdminById(UUID keycloakId, UserSearchRequest search, Pageable pageable);
 }

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserQuery.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserQuery.java
@@ -1,0 +1,15 @@
+package com.sparta.deliveryi.user.application.service;
+
+import com.sparta.deliveryi.user.application.dto.AdminUserResponse;
+import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
+import com.sparta.deliveryi.user.application.dto.UserResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserQuery {
+    MyInfoResponse getMyInfo(UUID id);
+    UserResponse getUserById(UUID id);
+    AdminUserResponse getUserForAdminById(UUID id);
+    List<AdminUserResponse> getUsersForAdminById();
+}

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserQuery.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserQuery.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.UUID;
 
 public interface UserQuery {
-    MyInfoResponse getMyInfo(UUID keycloakId, UUID userId);
+    MyInfoResponse getMyInfo(UUID keycloakId);
     UserResponse getUserById(UUID userId);
 
     AdminUserResponse getUserForAdminById(UUID keycloakId, UUID userId);

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserQueryService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserQueryService.java
@@ -3,12 +3,15 @@ package com.sparta.deliveryi.user.application.service;
 import com.sparta.deliveryi.user.application.dto.AdminUserResponse;
 import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
 import com.sparta.deliveryi.user.application.dto.UserResponse;
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import com.sparta.deliveryi.user.domain.*;
 import com.sparta.deliveryi.user.domain.service.UserFinder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -16,25 +19,94 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class UserQueryService implements UserQuery {
 
-    private final UserFinder userFinder;
+    private UserRoleService userRoleService;
+    private UserFinder userFinder;
 
     @Override
-    public MyInfoResponse getMyInfo(UUID id) {
-        return null;
+    public MyInfoResponse getMyInfo(UUID keycloakId, UUID userId) {
+        User user = userFinder.find(UserId.of(userId))
+                .orElseThrow(() -> new UserException(UserMessageCode.USER_NOT_FOUND));
+
+        if (!user.getKeycloakId().toUuid().equals(keycloakId)) {
+            throw new UserException(UserMessageCode.READ_FORBIDDEN);
+        }
+
+        return MyInfoResponse.builder()
+                .userId(user.getId().toUuid())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .userPhone(user.getUserPhone().formatted())
+                .currentAddress(user.getCurrentAddress())
+                .createdAt(user.getCreatedAt())
+                .createdBy(user.getCreatedBy())
+                .build();
     }
 
     @Override
-    public UserResponse getUserById(UUID id) {
-        return null;
+    public UserResponse getUserById(UUID userId) {
+        User user = userFinder.find(UserId.of(userId))
+                .orElseThrow(() -> new UserException(UserMessageCode.USER_NOT_FOUND));
+
+        return UserResponse.builder()
+                .userId(user.getId().toUuid())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .createdAt(user.getCreatedAt())
+                .createdBy(user.getCreatedBy())
+                .build();
     }
 
     @Override
-    public AdminUserResponse getUserForAdminById(UUID id) {
-        return null;
+    public AdminUserResponse getUserForAdminById(UUID keycloakId, UUID userId) {
+        User loginUser = userFinder.findByKeycloakId(KeycloakId.of(keycloakId))
+                .orElseThrow(() -> new UserException(UserMessageCode.USER_NOT_FOUND));
+
+        if (!userRoleService.isAdmin(loginUser.getId().toUuid())) {
+            throw new UserException(UserMessageCode.ACCESS_FORBIDDEN);
+        }
+
+        User user = userFinder.find(UserId.of(userId))
+                .orElseThrow(() -> new UserException(UserMessageCode.USER_NOT_FOUND));
+
+        return AdminUserResponse.builder()
+                .userId(user.getId().toUuid())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .currentAddress(user.getCurrentAddress())
+                .createdAt(user.getCreatedAt())
+                .createdBy(user.getCreatedBy())
+                .updatedAt(user.getUpdatedAt())
+                .updatedBy(user.getUpdatedBy())
+                .deletedAt(user.getDeletedAt())
+                .deletedBy(user.getDeletedBy())
+                .build();
     }
 
     @Override
-    public List<AdminUserResponse> getUsersForAdminById() {
-        return List.of();
+    public Page<AdminUserResponse> searchUsersForAdminById(UUID keycloakId, UserSearchRequest search, Pageable pageable) {
+        User loginUser = userFinder.findByKeycloakId(KeycloakId.of(keycloakId))
+                .orElseThrow(() -> new UserException(UserMessageCode.USER_NOT_FOUND));
+
+        if (!userRoleService.isAdmin(loginUser.getId().toUuid())) {
+            throw new UserException(UserMessageCode.ACCESS_FORBIDDEN);
+        }
+
+        return userFinder.search(search, pageable)
+                .map(user -> AdminUserResponse.builder()
+                        .userId(user.getId().toUuid())
+                        .username(user.getUsername())
+                        .nickname(user.getNickname())
+                        .role(user.getRole())
+                        .currentAddress(user.getCurrentAddress())
+                        .createdAt(user.getCreatedAt())
+                        .createdBy(user.getCreatedBy())
+                        .updatedAt(user.getUpdatedAt())
+                        .updatedBy(user.getUpdatedBy())
+                        .deletedAt(user.getDeletedAt())
+                        .deletedBy(user.getDeletedBy())
+                        .build());
     }
 }

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserQueryService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserQueryService.java
@@ -23,13 +23,9 @@ public class UserQueryService implements UserQuery {
     private UserFinder userFinder;
 
     @Override
-    public MyInfoResponse getMyInfo(UUID keycloakId, UUID userId) {
-        User user = userFinder.find(UserId.of(userId))
+    public MyInfoResponse getMyInfo(UUID keycloakId) {
+        User user = userFinder.findByKeycloakId(KeycloakId.of(keycloakId))
                 .orElseThrow(() -> new UserException(UserMessageCode.USER_NOT_FOUND));
-
-        if (!user.getKeycloakId().toUuid().equals(keycloakId)) {
-            throw new UserException(UserMessageCode.READ_FORBIDDEN);
-        }
 
         return MyInfoResponse.builder()
                 .userId(user.getId().toUuid())

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserQueryService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserQueryService.java
@@ -1,0 +1,40 @@
+package com.sparta.deliveryi.user.application.service;
+
+import com.sparta.deliveryi.user.application.dto.AdminUserResponse;
+import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
+import com.sparta.deliveryi.user.application.dto.UserResponse;
+import com.sparta.deliveryi.user.domain.service.UserFinder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserQueryService implements UserQuery {
+
+    private final UserFinder userFinder;
+
+    @Override
+    public MyInfoResponse getMyInfo(UUID id) {
+        return null;
+    }
+
+    @Override
+    public UserResponse getUserById(UUID id) {
+        return null;
+    }
+
+    @Override
+    public AdminUserResponse getUserForAdminById(UUID id) {
+        return null;
+    }
+
+    @Override
+    public List<AdminUserResponse> getUsersForAdminById() {
+        return List.of();
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserRegisterService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserRegisterService.java
@@ -6,7 +6,7 @@ import com.sparta.deliveryi.user.domain.dto.UserCreateRequest;
 import com.sparta.deliveryi.user.domain.service.UserCreate;
 import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakUser;
 import com.sparta.deliveryi.user.infrastructure.keycloak.dto.KeycloakRegisterRequest;
-import com.sparta.deliveryi.user.infrastructure.keycloak.service.KeycloakRegister;
+import com.sparta.deliveryi.user.infrastructure.keycloak.service.AuthRegister;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +19,7 @@ import org.springframework.validation.annotation.Validated;
 @RequiredArgsConstructor
 public class UserRegisterService implements UserRegister {
 
-    private final KeycloakRegister keycloakRegister;
+    private final AuthRegister authRegister;
     private final UserCreate userCreate;
 
     @Override
@@ -28,7 +28,7 @@ public class UserRegisterService implements UserRegister {
                 .username(request.username())
                 .password(request.password())
                 .build();
-        KeycloakUser keycloakUser = keycloakRegister.register(keycloakRegisterRequest);
+        KeycloakUser keycloakUser = authRegister.register(keycloakRegisterRequest);
 
         UserCreateRequest userCreateRequest = UserCreateRequest.builder()
                 .keycloakUser(keycloakUser)

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserRoleService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserRoleService.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 
 public interface UserRoleService {
     boolean isAdmin(UUID userId);
+    boolean isCustomer(UUID userId);
+    boolean isOwner(UUID userId);
 
     void updateUserRole(UUID userId, UserRole role);
 }

--- a/src/main/java/com/sparta/deliveryi/user/domain/KeycloakId.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/KeycloakId.java
@@ -30,6 +30,10 @@ public class KeycloakId {
         return new KeycloakId(UUID.fromString(id));
     }
 
+    public UUID toUuid() {
+        return id;
+    }
+
     public String toString() {
         return id.toString();
     }

--- a/src/main/java/com/sparta/deliveryi/user/domain/KeycloakId.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/KeycloakId.java
@@ -29,4 +29,8 @@ public class KeycloakId {
     public static KeycloakId of(String id) {
         return new KeycloakId(UUID.fromString(id));
     }
+
+    public String toString() {
+        return id.toString();
+    }
 }

--- a/src/main/java/com/sparta/deliveryi/user/domain/UserId.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/UserId.java
@@ -21,5 +21,7 @@ public class UserId {
 
     public static UserId of(UUID id) { return new UserId(id); }
 
+    public UUID toUuid() { return id; }
+
     public String toString() { return id.toString(); }
 }

--- a/src/main/java/com/sparta/deliveryi/user/domain/UserMessageCode.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/UserMessageCode.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserMessageCode implements MessageCode {
-    NOT_FOUND("USER.NOT_FOUND", HttpStatus.NOT_FOUND),
+    READ_FORBIDDEN("USER.READ_FORBIDDEN", HttpStatus.FORBIDDEN),
+    UPDATE_FORBIDDEN("USER.UPDATE_FORBIDDEN", HttpStatus.FORBIDDEN),
+    ACCESS_FORBIDDEN("USER.ACCESS_FORBIDDEN", HttpStatus.FORBIDDEN),
+    USER_NOT_FOUND("USER.USER_NOT_FOUND", HttpStatus.NOT_FOUND),
     PASSWORD_MISMATCH("USER.PASSWORD_MISMATCH", HttpStatus.BAD_REQUEST);
 
     private final String code;

--- a/src/main/java/com/sparta/deliveryi/user/domain/UserRepository.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/UserRepository.java
@@ -1,13 +1,17 @@
 package com.sparta.deliveryi.user.domain;
 
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends Repository<User, UserId> {
+public interface UserRepository extends Repository<User, UserId>, UserRepositoryCustom {
     User save(User user);
 
     Optional<User> findById(UserId userId);
-    List<User> findAll();
+    Optional<User> findByKeycloakId(KeycloakId keycloakId);
+
+    Page<User> search(UserSearchRequest search, Pageable pageable);
 }

--- a/src/main/java/com/sparta/deliveryi/user/domain/UserRepositoryCustom.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/UserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryi.user.domain;
+
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserRepositoryCustom {
+    Page<User> search(UserSearchRequest search, Pageable pageable);
+}

--- a/src/main/java/com/sparta/deliveryi/user/domain/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/UserRepositoryCustomImpl.java
@@ -1,0 +1,70 @@
+package com.sparta.deliveryi.user.domain;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<User> search(UserSearchRequest search, Pageable pageable) {
+        QUser user = QUser.user;
+
+        // 검색조건
+        BooleanBuilder builder = new BooleanBuilder();
+        if (search.username() != null && !search.username().isBlank()) {
+            builder.and(user.username.containsIgnoreCase(search.username()));
+        }
+        if (search.nickname() != null && !search.nickname().isBlank()) {
+            builder.and(user.nickname.containsIgnoreCase(search.nickname()));
+        }
+        if (search.role() != null) {
+            builder.and(user.role.eq(search.role()));
+        }
+
+        List<User> content = queryFactory
+                .selectFrom(user)
+                .where(builder)
+                .orderBy(getOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(
+                queryFactory.select(user.count()).from(user).where(builder).fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        PathBuilder<User> pathBuilder = new PathBuilder<>(User.class, "user");
+
+        for (Sort.Order order : sort) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            orders.add(new OrderSpecifier<>(direction, pathBuilder.getString(order.getProperty())));
+        }
+
+        orders.add(new OrderSpecifier<>(Order.DESC, pathBuilder.getDateTime("createdAt", LocalDateTime.class)));
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/user/domain/service/UserFinder.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/service/UserFinder.java
@@ -1,11 +1,16 @@
 package com.sparta.deliveryi.user.domain.service;
 
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import com.sparta.deliveryi.user.domain.KeycloakId;
 import com.sparta.deliveryi.user.domain.User;
 import com.sparta.deliveryi.user.domain.UserId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface UserFinder {
-    User find(UserId userId);
-    List<User> findAll();
+    Optional<User> find(UserId userId);
+    Optional<User> findByKeycloakId(KeycloakId keycloakId);
+    Page<User> search(UserSearchRequest search,  Pageable pageable);
 }

--- a/src/main/java/com/sparta/deliveryi/user/domain/service/UserFinderService.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/service/UserFinderService.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class UserQueryService implements UserFinder {
+public class UserFinderService implements UserFinder {
 
     private final UserRepository userRepository;
 

--- a/src/main/java/com/sparta/deliveryi/user/domain/service/UserFinderService.java
+++ b/src/main/java/com/sparta/deliveryi/user/domain/service/UserFinderService.java
@@ -1,11 +1,17 @@
 package com.sparta.deliveryi.user.domain.service;
 
-import com.sparta.deliveryi.user.domain.*;
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import com.sparta.deliveryi.user.domain.KeycloakId;
+import com.sparta.deliveryi.user.domain.User;
+import com.sparta.deliveryi.user.domain.UserId;
+import com.sparta.deliveryi.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,13 +21,17 @@ public class UserFinderService implements UserFinder {
     private final UserRepository userRepository;
 
     @Override
-    public User find(UserId userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저 정보를 찾을 수 없습니다. id: " + userId));
+    public Optional<User> find(UserId userId) {
+        return userRepository.findById(userId);
     }
 
     @Override
-    public List<User> findAll() {
-        return userRepository.findAll();
+    public Optional<User> findByKeycloakId(KeycloakId keycloakId) {
+        return userRepository.findByKeycloakId(keycloakId);
+    }
+
+    @Override
+    public Page<User> search(UserSearchRequest search, Pageable pageable) {
+        return userRepository.search(search, pageable);
     }
 }

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/KeycloakException.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/KeycloakException.java
@@ -1,0 +1,10 @@
+package com.sparta.deliveryi.user.infrastructure.keycloak;
+
+import com.sparta.deliveryi.global.exception.AbstractException;
+import com.sparta.deliveryi.global.exception.MessageCode;
+
+public class KeycloakException extends AbstractException {
+    public KeycloakException(MessageCode messageCode) {
+        super(messageCode);
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/KeycloakMessageCode.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/KeycloakMessageCode.java
@@ -1,0 +1,15 @@
+package com.sparta.deliveryi.user.infrastructure.keycloak;
+
+import com.sparta.deliveryi.global.exception.MessageCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum KeycloakMessageCode implements MessageCode {
+    NOT_FOUND("KEYCLOAK.NOT_FOUND", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthFinder.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthFinder.java
@@ -3,6 +3,9 @@ package com.sparta.deliveryi.user.infrastructure.keycloak.service;
 import com.sparta.deliveryi.user.domain.KeycloakId;
 import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakUser;
 
+import java.util.List;
+
 public interface AuthFinder {
     KeycloakUser find(KeycloakId keycloakId);
+    List<KeycloakUser> findAll();
 }

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthFinder.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthFinder.java
@@ -1,0 +1,8 @@
+package com.sparta.deliveryi.user.infrastructure.keycloak.service;
+
+import com.sparta.deliveryi.user.domain.KeycloakId;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakUser;
+
+public interface AuthFinder {
+    KeycloakUser find(KeycloakId keycloakId);
+}

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthRegister.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthRegister.java
@@ -4,6 +4,6 @@ import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakUser;
 import com.sparta.deliveryi.user.infrastructure.keycloak.dto.KeycloakRegisterRequest;
 import jakarta.validation.Valid;
 
-public interface KeycloakRegister {
+public interface AuthRegister {
     KeycloakUser register(@Valid KeycloakRegisterRequest request);
 }

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakQueryService.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakQueryService.java
@@ -1,0 +1,44 @@
+package com.sparta.deliveryi.user.infrastructure.keycloak.service;
+
+import com.sparta.deliveryi.user.domain.KeycloakId;
+import com.sparta.deliveryi.user.domain.UserRole;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakException;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakMessageCode;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakProperties;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakUser;
+import jakarta.ws.rs.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class KeycloakQueryService implements AuthFinder {
+
+    private final KeycloakProperties properties;
+    private final Keycloak keycloak;
+
+    @Override
+    public KeycloakUser find(KeycloakId keycloakId) {
+
+        try {
+            UserRepresentation user = keycloak.realm(properties.getRealm())
+                    .users()
+                    .get(keycloakId.toString())
+                    .toRepresentation();
+
+            return KeycloakUser.builder()
+                    .id(UUID.fromString(user.getId()))
+                    .username(user.getUsername())
+                    .role(UserRole.valueOf(user.getAttributes().get("role").getFirst()))
+                    .build();
+        } catch (NotFoundException e) {
+            throw new KeycloakException(KeycloakMessageCode.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakQueryService.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakQueryService.java
@@ -40,6 +40,8 @@ public class KeycloakQueryService implements AuthFinder {
                     .build();
         } catch (NotFoundException e) {
             throw new KeycloakException(KeycloakMessageCode.NOT_FOUND);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakRegisterService.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakRegisterService.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 @Validated
 @RequiredArgsConstructor
 @EnableConfigurationProperties(KeycloakProperties.class)
-public class KeycloakRegisterService implements KeycloakRegister {
+public class KeycloakRegisterService implements AuthRegister {
 
     private final KeycloakProperties properties;
     private final Keycloak keycloak;

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
@@ -15,6 +15,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,8 +40,20 @@ public class AdminUserApi {
             UserSearchRequest searchRequest,
             @PageableDefault Pageable pageable
     ) {
-        Page<AdminUserResponse> users = userQuery.searchUsersForAdminById(UUID.fromString(jwt.getSubject()), searchRequest, pageable);
+        Page<AdminUserResponse> response = userQuery.searchUsersForAdminById(UUID.fromString(jwt.getSubject()), searchRequest, pageable);
 
-        return ok(successWithDataOnly(users));
+        return ok(successWithDataOnly(response));
+    }
+
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @Operation(summary = "특정 회원 정보 조회(관리자용)", description = "UserId로 다른 회원의 모든 정보를 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<AdminUserResponse>> getMyInfo(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID userId
+    ) {
+        AdminUserResponse response = userQuery.getUserForAdminById(UUID.fromString(jwt.getSubject()), userId);
+
+        return ok(successWithDataOnly(response));
     }
 }

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
@@ -1,0 +1,46 @@
+package com.sparta.deliveryi.user.presentation.webapi;
+
+import com.sparta.deliveryi.global.presentation.dto.ApiResponse;
+import com.sparta.deliveryi.user.application.dto.AdminUserResponse;
+import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import com.sparta.deliveryi.user.application.service.UserQuery;
+import lombok.RequiredArgsConstructor;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+import static com.sparta.deliveryi.global.presentation.dto.ApiResponse.successWithDataOnly;
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/admin/users")
+@Tag(name = "회원 API(관리자용)", description = "관리자용 API로, 회원 정보 조회 시 모든 항목을 확인할 수 있습니다.")
+public class AdminUserApi {
+
+    private final UserQuery userQuery;
+
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @Operation(summary = "회원 목록 조회", description = "등록된 모든 회원 정보를 조회합니다.")
+    @GetMapping("/all")
+    public ResponseEntity<ApiResponse<Page<AdminUserResponse>>> search(
+            @AuthenticationPrincipal Jwt jwt,
+            UserSearchRequest searchRequest,
+            @PageableDefault Pageable pageable
+    ) {
+        Page<AdminUserResponse> users = userQuery.searchUsersForAdminById(UUID.fromString(jwt.getSubject()), searchRequest, pageable);
+
+        return ok(successWithDataOnly(users));
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
@@ -20,12 +20,12 @@ import static org.springframework.http.ResponseEntity.ok;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/users")
-@Tag(name="회원 API", description = "")
+@Tag(name = "회원 API", description = "")
 public class UserApi {
 
     private final UserRegister userService;
 
-    @Operation(summary = "회원가입", description = "신규 사용자를 등록합니다. 가입 시 기본 권한은 'CUSTOMER' 입니다.")
+    @Operation(summary = "회원가입", description = "신규 회원을 등록합니다. 가입 시 기본 권한은 'CUSTOMER' 입니다.")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupReqeust request) {
@@ -45,4 +45,6 @@ public class UserApi {
 
         return ok(success());
     }
+
+
 }

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
@@ -1,7 +1,10 @@
 package com.sparta.deliveryi.user.presentation.webapi;
 
 import com.sparta.deliveryi.global.presentation.dto.ApiResponse;
+import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
 import com.sparta.deliveryi.user.application.dto.UserRegisterRequest;
+import com.sparta.deliveryi.user.application.dto.UserResponse;
+import com.sparta.deliveryi.user.application.service.UserQuery;
 import com.sparta.deliveryi.user.application.service.UserRegister;
 import com.sparta.deliveryi.user.domain.UserException;
 import com.sparta.deliveryi.user.domain.UserMessageCode;
@@ -12,9 +15,14 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 import static com.sparta.deliveryi.global.presentation.dto.ApiResponse.success;
+import static com.sparta.deliveryi.global.presentation.dto.ApiResponse.successWithDataOnly;
 import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
@@ -23,7 +31,8 @@ import static org.springframework.http.ResponseEntity.ok;
 @Tag(name = "회원 API", description = "")
 public class UserApi {
 
-    private final UserRegister userService;
+    private final UserRegister userRegister;
+    private final UserQuery userQuery;
 
     @Operation(summary = "회원가입", description = "신규 회원을 등록합니다. 가입 시 기본 권한은 'CUSTOMER' 입니다.")
     @ResponseStatus(HttpStatus.CREATED)
@@ -41,10 +50,24 @@ public class UserApi {
                 .currentAddress(request.currentAddress())
                 .build();
 
-        userService.register(registerRequest);
+        userRegister.register(registerRequest);
 
         return ok(success());
     }
 
+    @Operation(summary = "로그인한 회원 정보 조회", description = "로그인한 회원의 정보를 조회합니다.")
+    @GetMapping()
+    public ResponseEntity<ApiResponse<MyInfoResponse>> getMyInfo(@AuthenticationPrincipal Jwt jwt) {
+        MyInfoResponse response = userQuery.getMyInfo(UUID.fromString(jwt.getSubject()));
 
+        return ok(successWithDataOnly(response));
+    }
+
+    @Operation(summary = "특정 회원 정보 조회", description = "UserId로 다른 회원의 정보를 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(@PathVariable UUID userId) {
+        UserResponse response = userQuery.getUserById(userId);
+
+        return ok(successWithDataOnly(response));
+    }
 }

--- a/src/test/java/com/sparta/deliveryi/user/service/UserFinderServiceTest.java
+++ b/src/test/java/com/sparta/deliveryi/user/service/UserFinderServiceTest.java
@@ -5,11 +5,15 @@ import com.sparta.deliveryi.user.domain.User;
 import com.sparta.deliveryi.user.domain.UserId;
 import com.sparta.deliveryi.user.domain.dto.UserCreateRequest;
 import com.sparta.deliveryi.user.domain.service.UserCreate;
-import com.sparta.deliveryi.user.domain.service.UserFinderService;
+import com.sparta.deliveryi.user.domain.service.UserFinder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -27,7 +31,7 @@ public class UserFinderServiceTest {
     private UserCreate userCreate;
 
     @Autowired
-    private UserFinderService userFinderService;
+    private UserFinder userFinder;
 
     List<User> users;
     int size = 10;
@@ -45,7 +49,8 @@ public class UserFinderServiceTest {
     @Test
     void findWithValidId() {
         User targetUser = users.getFirst();
-        User result = userFinderService.find(targetUser.getId());
+        User result = userFinder.find(targetUser.getId())
+                .orElseThrow(AssertionError::new);
         assertThat(result.getId()).isNotNull();
     }
 
@@ -54,15 +59,17 @@ public class UserFinderServiceTest {
         UserId invalidUserId = UserId.of(UUID.randomUUID());
 
         assertThrows(IllegalArgumentException.class, () -> {
-           userFinderService.find(invalidUserId);
+           userFinder.find(invalidUserId);
         });
     }
 
     @Test
     void findAll() {
-        List<User> result = userFinderService.findAll();
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
 
-        assertThat(users.size()).isEqualTo(size);
+        Page<User> result = userFinder.findAll(pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(users.size());
 
         List<UserId> userIds = users.stream().map(User::getId).toList();
         List<UserId> resultIds = result.stream().map(User::getId).toList();

--- a/src/test/java/com/sparta/deliveryi/user/service/UserFinderServiceTest.java
+++ b/src/test/java/com/sparta/deliveryi/user/service/UserFinderServiceTest.java
@@ -5,7 +5,7 @@ import com.sparta.deliveryi.user.domain.User;
 import com.sparta.deliveryi.user.domain.UserId;
 import com.sparta.deliveryi.user.domain.dto.UserCreateRequest;
 import com.sparta.deliveryi.user.domain.service.UserCreate;
-import com.sparta.deliveryi.user.domain.service.UserQueryService;
+import com.sparta.deliveryi.user.domain.service.UserFinderService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,13 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
-public class UserQueryServiceTest {
+public class UserFinderServiceTest {
 
     @Autowired
     private UserCreate userCreate;
 
     @Autowired
-    private UserQueryService userQueryService;
+    private UserFinderService userFinderService;
 
     List<User> users;
     int size = 10;
@@ -45,7 +45,7 @@ public class UserQueryServiceTest {
     @Test
     void findWithValidId() {
         User targetUser = users.getFirst();
-        User result = userQueryService.find(targetUser.getId());
+        User result = userFinderService.find(targetUser.getId());
         assertThat(result.getId()).isNotNull();
     }
 
@@ -54,13 +54,13 @@ public class UserQueryServiceTest {
         UserId invalidUserId = UserId.of(UUID.randomUUID());
 
         assertThrows(IllegalArgumentException.class, () -> {
-           userQueryService.find(invalidUserId);
+           userFinderService.find(invalidUserId);
         });
     }
 
     @Test
     void findAll() {
-        List<User> result = userQueryService.findAll();
+        List<User> result = userFinderService.findAll();
 
         assertThat(users.size()).isEqualTo(size);
 


### PR DESCRIPTION
## 📝 요약 (Summary)
특정 회원정보 및 모든 회원 정보를 조회합니다.

## 🛠️ 작업 내용 (Details)
- 모든 회원정보 조회 (관리자용)
  - 회원정보 + Audit
  - 페이징, 검색, 정렬 기능
  - 검색: username, nickname, role
  - 정렬: createdAt(default) 
    - users?sort=필드명,정렬방향
- 특정 회원정보 조회 (관리자용)
- 특정 회원정보 조회 (전화번호, 현재 주소 제외)
- 로그인한 회원정보 조회 (헤더의 keycloakId를 사용한 조회)


## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
- 로그인한 회원정보 조회 : GET /v1/users
- 특정 회원정보 조회 : GET /v1/users/{userId}
- 특정 회원정보 조회(관리자용) : GET /v1/admin/users/{userId}
- 모든 회원정보 조회 : GET /v1/admin/users/all

close #42