### PR TITLE
[STORE] 이벤트 발행 위치 변경 #53

### DIFF
--- a/src/main/java/com/sparta/deliveryi/store/application/service/StoreApplication.java
+++ b/src/main/java/com/sparta/deliveryi/store/application/service/StoreApplication.java
@@ -2,13 +2,10 @@ package com.sparta.deliveryi.store.application.service;
 
 import com.sparta.deliveryi.store.domain.Store;
 import com.sparta.deliveryi.store.domain.StoreInfoUpdateRequest;
-import com.sparta.deliveryi.store.domain.StoreRegisterRequest;
 
 import java.util.UUID;
 
 public interface StoreApplication {
-    Store register(StoreRegisterRequest registerRequest, UUID requestId);
-
     Store updateInfo(UUID storeId, StoreInfoUpdateRequest updateRequest, UUID requestId);
 
     Store remove(UUID storeId, UUID requestId);

--- a/src/main/java/com/sparta/deliveryi/store/domain/event/StoreRegisterAcceptEvent.java
+++ b/src/main/java/com/sparta/deliveryi/store/domain/event/StoreRegisterAcceptEvent.java
@@ -2,5 +2,5 @@ package com.sparta.deliveryi.store.domain.event;
 
 import java.util.UUID;
 
-public record StoreRegisterEvent(UUID userId) {
+public record StoreRegisterAcceptEvent(UUID userId) {
 }

--- a/src/main/java/com/sparta/deliveryi/store/presentation/webapi/StoreApi.java
+++ b/src/main/java/com/sparta/deliveryi/store/presentation/webapi/StoreApi.java
@@ -29,10 +29,8 @@ public class StoreApi {
     private final StoreApplication storeApplication;
 
     @PostMapping("/v1/stores")
-    public ResponseEntity<ApiResponse<StoreRegisterResponse>> register(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid StoreRegisterRequest registerRequest) {
-        UUID requestId = UUID.fromString(jwt.getSubject());
-
-        Store store = storeApplication.register(registerRequest, requestId);
+    public ResponseEntity<ApiResponse<StoreRegisterResponse>> register(@RequestBody @Valid StoreRegisterRequest registerRequest) {
+        Store store = storeRegister.register(registerRequest);
 
         return ok(successWithDataOnly(StoreRegisterResponse.from(store)));
     }

--- a/src/test/java/com/sparta/deliveryi/store/application/service/StoreApplicationTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/application/service/StoreApplicationTest.java
@@ -2,7 +2,10 @@ package com.sparta.deliveryi.store.application.service;
 
 import com.sparta.deliveryi.DeliveryITestConfiguration;
 import com.sparta.deliveryi.store.StoreFixture;
-import com.sparta.deliveryi.store.domain.*;
+import com.sparta.deliveryi.store.domain.Owner;
+import com.sparta.deliveryi.store.domain.Store;
+import com.sparta.deliveryi.store.domain.StoreInfoUpdateRequest;
+import com.sparta.deliveryi.store.domain.StoreStatus;
 import com.sparta.deliveryi.store.domain.service.StoreFinder;
 import com.sparta.deliveryi.store.domain.service.StoreRegister;
 import jakarta.persistence.EntityManager;
@@ -24,15 +27,6 @@ record StoreApplicationTest(
         StoreFinder storeFinder,
         EntityManager entityManager
 ) {
-    @Test
-    void register() {
-        StoreRegisterRequest request = StoreFixture.createStoreRegisterRequest();
-
-        Store store = storeApplication.register(request, UUID.randomUUID());
-
-        assertThat(store.getId()).isNotNull();
-    }
-
     @Test
     void updateInfo() {
         Store store = registerStore();

--- a/src/test/java/com/sparta/deliveryi/store/presentation/webapi/StoreApiTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/presentation/webapi/StoreApiTest.java
@@ -45,7 +45,6 @@ class StoreApiTest {
     void register() throws JsonProcessingException {
         StoreRegisterRequest request = StoreFixture.createStoreRegisterRequest();
         String requestJson = objectMapper.writeValueAsString(request);
-        mockedToken(UUID.randomUUID().toString(), "CUSTOMER");
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores")


### PR DESCRIPTION
See also: #53

## 📝 요약 (Summary)
이벤트 발행 위치 변경 

## 🛠️ 작업 내용 (Details)
1. 고객에서 가게 주인으로 권한을 변경하는 시점은 가게 등록 승인 이후라고 생각되어 등록 승인 이벤트 발행하는 것으로 변경
2. 각 이벤트는 등록 승인, 삭제, 인수인계에 대한 이벤트로 도메인 기능 안으로 이동하였음.
3. 유저 권한 수정에 필요한 판단 등에 관련된 로직은 이벤트 리스너에 필요하다고 판단되어 해당 로직 제거하였음.

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)