### PR TITLE
[USER] 회원 로그아웃, 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserApplication.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserApplication.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryi.user.application.service;
+
+import java.util.UUID;
+
+public interface UserApplication {
+    void logout(UUID keycloakId);
+    void delete(UUID keycloakId);
+    void deleteForce(UUID keycloakId, UUID userId);
+}

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserApplicationService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserApplicationService.java
@@ -1,0 +1,46 @@
+package com.sparta.deliveryi.user.application.service;
+
+import com.sparta.deliveryi.user.domain.KeycloakId;
+import com.sparta.deliveryi.user.domain.service.UserFinder;
+import com.sparta.deliveryi.user.infrastructure.keycloak.service.AuthService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserApplicationService implements UserApplication {
+
+    private final AuthService keycloakService;
+    private final UserFinder userFiner;
+    // private final UserRolePolicy userRolePolicy;
+
+    @Override
+    public void logout(UUID keycloakId) {
+        keycloakService.logout(KeycloakId.of(keycloakId));
+    }
+
+    @Override
+    public void delete(UUID keycloakId) {
+        // UserId 조회
+
+        // Application DB Soft 삭제
+
+        // Keycloak 삭제
+        keycloakService.delete(KeycloakId.of(keycloakId));
+    }
+
+    @Override
+    public void deleteForce(UUID keycloakId, UUID userId) {
+        // loginUser 조회 및 역할 검증
+
+        // UserId 조회
+
+        // Application DB Soft 삭제 -> deletedBy 수동 업데이트
+
+        // Keycloak 삭제
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/user/application/service/UserApplicationService.java
+++ b/src/main/java/com/sparta/deliveryi/user/application/service/UserApplicationService.java
@@ -1,14 +1,10 @@
 package com.sparta.deliveryi.user.application.service;
 
-import com.sparta.deliveryi.user.domain.KeycloakId;
-import com.sparta.deliveryi.user.domain.UserException;
-import com.sparta.deliveryi.user.domain.UserId;
-import com.sparta.deliveryi.user.domain.UserMessageCode;
+import com.sparta.deliveryi.user.domain.*;
 import com.sparta.deliveryi.user.domain.service.UserFinder;
 import com.sparta.deliveryi.user.infrastructure.keycloak.service.AuthService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -50,10 +46,15 @@ public class UserApplicationService implements UserApplication {
     }
 
     private void deleteUser(User user) {
+        KeycloakId keycloakId = user.getKeycloakId();
+
+        // Token 무효화
+        keycloakService.logout(keycloakId);
+
         // Application DB Soft 삭제
         user.delete();
 
         // Keycloak 삭제
-        keycloakService.delete(KeycloakId.of(keycloakId));
+        keycloakService.delete(keycloakId);
     }
 }

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthService.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.sparta.deliveryi.user.infrastructure.keycloak.service;
+
+import com.sparta.deliveryi.user.domain.KeycloakId;
+
+public interface AuthService {
+    void logout(KeycloakId keycloakId);
+    void delete(KeycloakId keycloakId);
+}

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakService.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakService.java
@@ -28,7 +28,7 @@ public class KeycloakService implements AuthService {
         } catch (NotFoundException e) {
             throw new KeycloakException(KeycloakMessageCode.NOT_FOUND);
         } catch (Exception e) {
-            // throw new KeycloakException(KeycloakMessageCode.INTERNAL_FAILED, e);
+            throw new KeycloakException(KeycloakMessageCode.INTERNAL_FAILED, e);
         }
     }
 
@@ -40,7 +40,7 @@ public class KeycloakService implements AuthService {
         } catch (NotFoundException e) {
             throw new KeycloakException(KeycloakMessageCode.NOT_FOUND);
         } catch (Exception e) {
-            // throw new KeycloakException(KeycloakMessageCode.INTERNAL_FAILED, e);
+            throw new KeycloakException(KeycloakMessageCode.INTERNAL_FAILED, e);
         }
     }
 

--- a/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakService.java
+++ b/src/main/java/com/sparta/deliveryi/user/infrastructure/keycloak/service/KeycloakService.java
@@ -1,0 +1,47 @@
+package com.sparta.deliveryi.user.infrastructure.keycloak.service;
+
+import com.sparta.deliveryi.user.domain.KeycloakId;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakException;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakMessageCode;
+import com.sparta.deliveryi.user.infrastructure.keycloak.KeycloakProperties;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@EnableConfigurationProperties(KeycloakProperties.class)
+public class KeycloakService implements AuthService {
+
+    private final KeycloakProperties properties;
+    private final Keycloak keycloak;
+
+    public void logout(KeycloakId keycloakId) {
+        try {
+            UsersResource resource = keycloak.realm(properties.getRealm()).users();
+            resource.get(keycloakId.getId().toString()).logout();
+        } catch (NotFoundException e) {
+            throw new KeycloakException(KeycloakMessageCode.NOT_FOUND);
+        } catch (Exception e) {
+            // throw new KeycloakException(KeycloakMessageCode.INTERNAL_FAILED, e);
+        }
+    }
+
+    @Override
+    public void delete(KeycloakId keycloakId) {
+        try {
+            UsersResource resource = keycloak.realm(properties.getRealm()).users();
+            resource.delete(keycloakId.getId().toString());
+        } catch (NotFoundException e) {
+            throw new KeycloakException(KeycloakMessageCode.NOT_FOUND);
+        } catch (Exception e) {
+            // throw new KeycloakException(KeycloakMessageCode.INTERNAL_FAILED, e);
+        }
+    }
+
+}

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
@@ -76,7 +76,7 @@ public class AdminUserApi {
     }
 
     @Operation(summary = "회원탈퇴", description = "등록된 회원을 강제로 삭제합니다.")
-    @GetMapping("/{userId}")
+    @DeleteMapping("/{userId}")
     public ResponseEntity<ApiResponse<Void>> unsubscribe(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable UUID userId

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
@@ -75,6 +75,7 @@ public class AdminUserApi {
         return ok(success());
     }
 
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
     @Operation(summary = "회원탈퇴", description = "등록된 회원을 강제로 삭제합니다.")
     @DeleteMapping("/{userId}")
     public ResponseEntity<ApiResponse<Void>> unsubscribe(

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/AdminUserApi.java
@@ -3,6 +3,7 @@ package com.sparta.deliveryi.user.presentation.webapi;
 import com.sparta.deliveryi.global.presentation.dto.ApiResponse;
 import com.sparta.deliveryi.user.application.dto.AdminUserResponse;
 import com.sparta.deliveryi.user.application.dto.UserSearchRequest;
+import com.sparta.deliveryi.user.application.service.UserApplication;
 import com.sparta.deliveryi.user.application.service.UserModify;
 import com.sparta.deliveryi.user.application.service.UserQuery;
 import com.sparta.deliveryi.user.presentation.dto.UserRoleChangeRequest;
@@ -31,6 +32,7 @@ import static org.springframework.http.ResponseEntity.ok;
 @Tag(name = "회원 API(관리자용)", description = "관리자용 API로, 회원 정보 조회 시 모든 항목을 확인할 수 있습니다.")
 public class AdminUserApi {
 
+    private final UserApplication userService;
     private final UserQuery userQuery;
     private final UserModify userModify;
 
@@ -69,6 +71,17 @@ public class AdminUserApi {
             @Valid @RequestBody UserRoleChangeRequest request
     ) {
         userModify.modifyUserRole(UUID.fromString(jwt.getSubject()), userId, request.role());
+
+        return ok(success());
+    }
+
+    @Operation(summary = "회원탈퇴", description = "등록된 회원을 강제로 삭제합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Void>> unsubscribe(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID userId
+    ) {
+        userService.deleteForce(UUID.fromString(jwt.getSubject()), userId);
 
         return ok(success());
     }

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
@@ -123,7 +123,7 @@ public class UserApi {
     }
 
     @Operation(summary = "회원탈퇴", description = "로그인한 회원을 삭제합니다.")
-    @GetMapping("/{userId}")
+    @DeleteMapping("/{userId}")
     public ResponseEntity<ApiResponse<Void>> unsubscribe(@AuthenticationPrincipal Jwt jwt) {
         userService.delete(UUID.fromString(jwt.getSubject()));
 

--- a/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
+++ b/src/main/java/com/sparta/deliveryi/user/presentation/webapi/UserApi.java
@@ -1,12 +1,12 @@
 package com.sparta.deliveryi.user.presentation.webapi;
 
 import com.sparta.deliveryi.global.presentation.dto.ApiResponse;
+import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
 import com.sparta.deliveryi.user.application.dto.TokenInfo;
 import com.sparta.deliveryi.user.application.dto.UserRegisterRequest;
-import com.sparta.deliveryi.user.application.service.TokenGenerateService;
-import com.sparta.deliveryi.user.application.dto.MyInfoResponse;
-import com.sparta.deliveryi.user.application.dto.UserRegisterRequest;
 import com.sparta.deliveryi.user.application.dto.UserResponse;
+import com.sparta.deliveryi.user.application.service.TokenGenerateService;
+import com.sparta.deliveryi.user.application.service.UserApplication;
 import com.sparta.deliveryi.user.application.service.UserModify;
 import com.sparta.deliveryi.user.application.service.UserQuery;
 import com.sparta.deliveryi.user.application.service.UserRegister;
@@ -40,6 +40,7 @@ import static org.springframework.http.ResponseEntity.ok;
 public class UserApi {
 
     private final TokenGenerateService tokenService;
+    private final UserApplication userService;
     private final UserRegister userRegister;
     private final UserQuery userQuery;
     private final UserModify userModify;
@@ -76,6 +77,18 @@ public class UserApi {
                 .refreshToken(token.refresh_token())
                 .tokenType(token.token_type())
                 .build();
+
+        return ok(successWithDataOnly(response));
+    }
+
+    @Operation(summary = "로그아웃", description = "발급된 토큰을 무효화. 즉, 로그아웃합니다.")
+    @PostMapping("logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal Jwt jwt) {
+        userService.logout(UUID.fromString(jwt.getSubject()));
+
+        return ok(success());
+    }
+
     @Operation(summary = "로그인한 회원 정보 조회", description = "로그인한 회원의 정보를 조회합니다.")
     @GetMapping()
     public ResponseEntity<ApiResponse<MyInfoResponse>> getMyInfo(@AuthenticationPrincipal Jwt jwt) {
@@ -86,7 +99,7 @@ public class UserApi {
 
     @Operation(summary = "특정 회원 정보 조회", description = "UserId로 다른 회원의 정보를 조회합니다.")
     @GetMapping("/{userId}")
-    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(@PathVariable UUID userId) {
+    public ResponseEntity<ApiResponse<UserResponse>> getUserInfo(@PathVariable UUID userId) {
         UserResponse response = userQuery.getUserById(userId);
 
         return ok(successWithDataOnly(response));
@@ -105,6 +118,14 @@ public class UserApi {
                 .build();
 
         userModify.modifyUserInfo(UUID.fromString(jwt.getSubject()), updateRequest);
+
+        return ok(success());
+    }
+
+    @Operation(summary = "회원탈퇴", description = "로그인한 회원을 삭제합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Void>> unsubscribe(@AuthenticationPrincipal Jwt jwt) {
+        userService.delete(UUID.fromString(jwt.getSubject()));
 
         return ok(success());
     }


### PR DESCRIPTION
## 📝 요약 (Summary)
- 로그인한 회원은 로그아웃할 수 있음
- 로그인한 회원은 회원탈퇴할 수 있음
- 관리자는 등록된 회원을 탈퇴시킬 수 있음


## 🛠️ 작업 내용 (Details)
- 회원 로그아웃 및 회원탈퇴 API 구현
- 회원 로그아웃 시 발급된 토큰 무효화
- 회원탈퇴 시, 회원 삭제 전 발급된 토큰 무효화
  - 애플리케이션 DB는 Soft 삭제


## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
- Post /v1/users/logout : 로그아웃 
- Delete /v1/users : 로그인한 회원 탈퇴
- Delete /v1/admin/users/{userId} : 다른 회원 탈퇴 (관리자만 가능)

close #45