### PR TITLE
[ORDER] 주문 API 추가 #73

### DIFF
--- a/src/main/java/com/sparta/deliveryi/order/application/service/OrderApplicationService.java
+++ b/src/main/java/com/sparta/deliveryi/order/application/service/OrderApplicationService.java
@@ -27,6 +27,12 @@ public class OrderApplicationService implements OrderApplication {
 
     private final UserRolePolicy userRolePolicy;
 
+    private static void validateCanChange(Order order, UUID resolveRequestId) {
+        if (!order.getOrderer().getId().equals(resolveRequestId)) {
+            throw new IllegalArgumentException("변경 권한이 없습니다.");
+        }
+    }
+
     @Override
     public Order changeDeliveryAddress(UUID orderId, String deliveryAddress, UUID requestId) {
         Order order = orderFinder.find(OrderId.of(orderId));
@@ -75,12 +81,6 @@ public class OrderApplicationService implements OrderApplication {
 
     private UUID resolveRequestId(UUID requestId, Order order) {
         return isAdmin(requestId) ? order.getOrderer().getId() : requestId;
-    }
-
-    private static void validateCanChange(Order order, UUID resolveRequestId) {
-        if (!order.getOrderer().getId().equals(resolveRequestId)) {
-            throw new IllegalArgumentException("변경 권한이 없습니다.");
-        }
     }
 
     private void validateCanProcess(UUID orderId, UUID requestId) {

--- a/src/main/java/com/sparta/deliveryi/order/domain/Order.java
+++ b/src/main/java/com/sparta/deliveryi/order/domain/Order.java
@@ -121,7 +121,7 @@ public class Order extends AbstractEntity {
         this.status = OrderStatus.ORDER_COMPLETED;
     }
 
-    public Integer calculateTotalPrice() {
+    private Integer calculateTotalPrice() {
         return this.orderDetails.stream()
                 .map(OrderDetail::getOrderItem)
                 .mapToInt(OrderItem::totalPrice)

--- a/src/main/java/com/sparta/deliveryi/order/domain/service/OrderManageService.java
+++ b/src/main/java/com/sparta/deliveryi/order/domain/service/OrderManageService.java
@@ -20,6 +20,12 @@ public class OrderManageService implements OrderManager {
 
     private final OrderFinder orderFinder;
 
+    private static void checkOrderer(UUID requestId, Order order) {
+        if (!order.getOrderer().getId().equals(requestId)) {
+            throw new IllegalArgumentException("주문자 정보가 일치하지 않습니다.");
+        }
+    }
+
     @Override
     public Order changeDeliveryAddress(OrderId orderId, String deliveryAddress, UUID requestId) {
         Order order = orderFinder.find(orderId);
@@ -66,12 +72,6 @@ public class OrderManageService implements OrderManager {
         checkOrderer(requestId, order);
 
         order.cancel();
-    }
-
-    private static void checkOrderer(UUID requestId, Order order) {
-        if (!order.getOrderer().getId().equals(requestId)) {
-            throw new IllegalArgumentException("주문자 정보가 일치하지 않습니다.");
-        }
     }
 
     @Override

--- a/src/main/java/com/sparta/deliveryi/order/presentation/webapi/ChangeDeliveryAddressRequest.java
+++ b/src/main/java/com/sparta/deliveryi/order/presentation/webapi/ChangeDeliveryAddressRequest.java
@@ -1,0 +1,8 @@
+package com.sparta.deliveryi.order.presentation.webapi;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeDeliveryAddressRequest(
+        @NotNull String deliveryAddress
+) {
+}

--- a/src/main/java/com/sparta/deliveryi/order/presentation/webapi/ChangeDeliveryAddressResponse.java
+++ b/src/main/java/com/sparta/deliveryi/order/presentation/webapi/ChangeDeliveryAddressResponse.java
@@ -1,0 +1,14 @@
+package com.sparta.deliveryi.order.presentation.webapi;
+
+import com.sparta.deliveryi.order.domain.Order;
+
+import java.util.UUID;
+
+public record ChangeDeliveryAddressResponse(
+        UUID orderId,
+        String deliveryAddress
+) {
+    public static ChangeDeliveryAddressResponse from(Order order) {
+        return new ChangeDeliveryAddressResponse(order.getId().toUuid(), order.getDeliveryAddress());
+    }
+}

--- a/src/main/java/com/sparta/deliveryi/order/presentation/webapi/OrderApi.java
+++ b/src/main/java/com/sparta/deliveryi/order/presentation/webapi/OrderApi.java
@@ -1,0 +1,114 @@
+package com.sparta.deliveryi.order.presentation.webapi;
+
+import com.sparta.deliveryi.global.presentation.dto.ApiResponse;
+import com.sparta.deliveryi.order.application.service.OrderApplication;
+import com.sparta.deliveryi.order.domain.Order;
+import com.sparta.deliveryi.order.domain.OrderCreateRequest;
+import com.sparta.deliveryi.order.domain.OrderId;
+import com.sparta.deliveryi.order.domain.service.OrderCreator;
+import com.sparta.deliveryi.order.domain.service.OrderManager;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+import static com.sparta.deliveryi.global.presentation.dto.ApiResponse.success;
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderApi {
+
+    private final OrderCreator orderCreator;
+
+    private final OrderManager orderManager;
+
+    private final OrderApplication orderApplication;
+
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders")
+    public ResponseEntity<ApiResponse<OrderCreateResponse>> create(@RequestBody @Valid OrderCreateRequest createRequest) {
+        Order order = orderCreator.create(createRequest);
+
+        return ok(ApiResponse.successWithDataOnly(OrderCreateResponse.from(order)));
+    }
+
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
+    @PutMapping("/v1/orders/{orderId}/delivery-address")
+    public ResponseEntity<ApiResponse<ChangeDeliveryAddressResponse>> changeDeliveryAddress(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID orderId,
+            @RequestBody @Valid ChangeDeliveryAddressRequest changeRequest
+    ) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+        Order order = orderApplication.changeDeliveryAddress(orderId, changeRequest.deliveryAddress(), requestId);
+
+        return ok(ApiResponse.successWithDataOnly(ChangeDeliveryAddressResponse.from(order)));
+    }
+
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders/{orderId}/accept")
+    public ResponseEntity<ApiResponse<Void>> accept(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID orderId) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+
+        orderApplication.accept(orderId, requestId);
+
+        return ok(success());
+    }
+
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders/{orderId}/reject")
+    public ResponseEntity<ApiResponse<Void>> reject(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID orderId) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+
+        orderApplication.reject(orderId, requestId);
+
+        return ok(success());
+    }
+
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancel(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID orderId) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+
+        orderManager.cancel(OrderId.of(orderId), requestId);
+
+        return ok(success());
+    }
+
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders/{orderId}/complete-cooking")
+    public ResponseEntity<ApiResponse<Void>> completeCooking(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID orderId) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+
+        orderApplication.completeCooking(orderId, requestId);
+
+        return ok(success());
+    }
+
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders/{orderId}/delivery")
+    public ResponseEntity<ApiResponse<Void>> delivery(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID orderId) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+
+        orderApplication.delivery(orderId, requestId);
+
+        return ok(success());
+    }
+
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    @PostMapping("/v1/orders/{orderId}/complete")
+    public ResponseEntity<ApiResponse<Void>> complete(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID orderId) {
+        UUID requestId = UUID.fromString(jwt.getSubject());
+
+        orderApplication.complete(orderId, requestId);
+
+        return ok(success());
+    }
+
+}

--- a/src/main/java/com/sparta/deliveryi/order/presentation/webapi/OrderCreateResponse.java
+++ b/src/main/java/com/sparta/deliveryi/order/presentation/webapi/OrderCreateResponse.java
@@ -1,0 +1,14 @@
+package com.sparta.deliveryi.order.presentation.webapi;
+
+import com.sparta.deliveryi.order.domain.Order;
+
+import java.util.UUID;
+
+public record OrderCreateResponse(
+        UUID orderId,
+        int totalPrice
+) {
+    public static OrderCreateResponse from(Order order) {
+        return new OrderCreateResponse(order.getId().toUuid(), order.getTotalPrice());
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/MockUtils.java
+++ b/src/test/java/com/sparta/deliveryi/MockUtils.java
@@ -1,0 +1,52 @@
+package com.sparta.deliveryi;
+
+import com.sparta.deliveryi.user.domain.UserRole;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.List;
+
+public class MockUtils {
+    static final String MANAGER_UUID = "00000000-0000-0000-0000-000000000000";
+    static final String OWNER_UUID = "11111111-1111-1111-1111-111111111111";
+    static final String CUSTOMER_UUID = "22222222-2222-2222-2222-222222222222";
+
+    public static String managerId() {
+        return MANAGER_UUID;
+    }
+
+    public static String ownerId() {
+        return OWNER_UUID;
+    }
+
+    public static String customerId() {
+        return CUSTOMER_UUID;
+    }
+
+    public static void mockedMangerToken() {
+        mockedToken(MANAGER_UUID, UserRole.MANAGER.name());
+    }
+
+    public static void mockedOwnerToken() {
+        mockedToken(OWNER_UUID, UserRole.OWNER.name());
+    }
+
+    public static void mockedCustomerToken() {
+        mockedToken(CUSTOMER_UUID, UserRole.CUSTOMER.name());
+    }
+
+    private static void mockedToken(String subject, String role) {
+        Jwt jwt = Jwt.withTokenValue("dummy-token")
+                .header("alg", "none")
+                .subject(subject)
+                .build();
+
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(
+                jwt,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/order/OrderFixture.java
+++ b/src/test/java/com/sparta/deliveryi/order/OrderFixture.java
@@ -18,6 +18,13 @@ public class OrderFixture {
         return order;
     }
 
+    public static Order createOrder() {
+        Order order = Order.create(createOrderCreateRequest());
+        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+
+        return order;
+    }
+
     public static OrderCreateRequest createOrderCreateRequest() {
         OrderItem orderItem1 = OrderItem.of(1L, 5000, 2);
         OrderItem orderItem2 = OrderItem.of(2L, 10000, 1);

--- a/src/test/java/com/sparta/deliveryi/order/application/service/OrderApplicationTest.java
+++ b/src/test/java/com/sparta/deliveryi/order/application/service/OrderApplicationTest.java
@@ -38,6 +38,20 @@ class OrderApplicationTest {
     Order order;
 
     Store store;
+    @Autowired
+    private OrderManager orderManager;
+    @Autowired
+    private OrderFinder orderFinder;
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private OrderApplicationService orderApplicationService;
+    @Autowired
+    private OrderCreator orderCreator;
+    @MockitoBean
+    private StoreFinder storeFinder;
+    @MockitoBean
+    private UserRolePolicy userRolePolicy;
 
     @BeforeEach
     void setUp() {
@@ -288,25 +302,4 @@ class OrderApplicationTest {
 
         return order;
     }
-
-    @Autowired
-    private OrderManager orderManager;
-
-    @Autowired
-    private OrderFinder orderFinder;
-
-    @Autowired
-    private EntityManager entityManager;
-
-    @Autowired
-    private OrderApplicationService orderApplicationService;
-
-    @Autowired
-    private OrderCreator orderCreator;
-
-    @MockitoBean
-    private StoreFinder storeFinder;
-
-    @MockitoBean
-    private UserRolePolicy userRolePolicy;
 }

--- a/src/test/java/com/sparta/deliveryi/order/domain/OrderTest.java
+++ b/src/test/java/com/sparta/deliveryi/order/domain/OrderTest.java
@@ -167,7 +167,7 @@ class OrderTest {
 
     @Test
     void cancelIfAfterFiveMinute() {
-        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now().minusMinutes(5L));
+        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now().minusMinutes(6L));
 
         assertThatThrownBy(() -> order.cancel())
                 .isInstanceOf(OrderException.class);

--- a/src/test/java/com/sparta/deliveryi/order/presentation/webapi/OrderApiTest.java
+++ b/src/test/java/com/sparta/deliveryi/order/presentation/webapi/OrderApiTest.java
@@ -1,0 +1,274 @@
+package com.sparta.deliveryi.order.presentation.webapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.deliveryi.AssertThatUtils;
+import com.sparta.deliveryi.order.OrderFixture;
+import com.sparta.deliveryi.order.application.service.OrderApplication;
+import com.sparta.deliveryi.order.domain.Order;
+import com.sparta.deliveryi.order.domain.OrderCreateRequest;
+import com.sparta.deliveryi.order.domain.service.OrderCreator;
+import com.sparta.deliveryi.order.domain.service.OrderManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+import java.util.UUID;
+
+import static com.sparta.deliveryi.AssertThatUtils.isFalse;
+import static com.sparta.deliveryi.AssertThatUtils.isTrue;
+import static com.sparta.deliveryi.MockUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OrderApiTest {
+    @Autowired
+    MockMvcTester mvcTester;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    OrderCreator creator;
+
+    @MockitoBean
+    OrderManager manager;
+
+    @MockitoBean
+    OrderApplication application;
+    @Autowired
+    private OrderApplication orderApplication;
+    @Autowired
+    private OrderManager orderManager;
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void create() throws JsonProcessingException {
+        OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+        Order order = OrderFixture.createOrder();
+        given(creator.create(any(OrderCreateRequest.class))).willReturn(order);
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue())
+                .hasPathSatisfying("$.data", AssertThatUtils.notNull());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void changeDeliveryAddress() throws JsonProcessingException {
+        ChangeDeliveryAddressRequest request = new ChangeDeliveryAddressRequest("서울시 강남구 테스트로 12");
+        String requestJson = objectMapper.writeValueAsString(request);
+        Order order = OrderFixture.createOrder();
+        given(orderApplication.changeDeliveryAddress(eq(order.getId().toUuid()), anyString(), eq(UUID.fromString(customerId())))).willReturn(order);
+        mockedCustomerToken();
+
+        MvcTestResult result = mvcTester.put()
+                .uri("/v1/orders/{orderId}/delivery-address", order.getId().toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue())
+                .hasPathSatisfying("$.data", AssertThatUtils.notNull());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER")
+    void accept() {
+        Order order = OrderFixture.createOrder();
+        doNothing().when(orderApplication).accept(eq(order.getId().toUuid()), eq(UUID.fromString(customerId())));
+        mockedOwnerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/accept", order.getId().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void acceptIfUnauthorized() {
+        mockedCustomerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/accept", UUID.randomUUID().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatus(HttpStatus.FORBIDDEN)
+                .bodyJson()
+                .hasPathSatisfying("$.success", isFalse());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER")
+    void reject() {
+        Order order = OrderFixture.createOrder();
+        doNothing().when(orderApplication).reject(eq(order.getId().toUuid()), eq(UUID.fromString(customerId())));
+        mockedOwnerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/reject", order.getId().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void rejectIfUnauthorized() {
+        mockedCustomerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/reject", UUID.randomUUID().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatus(HttpStatus.FORBIDDEN)
+                .bodyJson()
+                .hasPathSatisfying("$.success", isFalse());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void cancel() {
+        Order order = OrderFixture.createOrder();
+        doNothing().when(orderManager).cancel(eq(order.getId()), eq(UUID.fromString(customerId())));
+        mockedOwnerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/cancel", order.getId().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER")
+    void completeCooking() {
+        Order order = OrderFixture.createOrder();
+        doNothing().when(orderApplication).completeCooking(eq(order.getId().toUuid()), eq(UUID.fromString(customerId())));
+        mockedOwnerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/complete-cooking", order.getId().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void completeCookingIfUnauthorized() {
+        mockedCustomerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/complete-cooking", UUID.randomUUID().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatus(HttpStatus.FORBIDDEN)
+                .bodyJson()
+                .hasPathSatisfying("$.success", isFalse());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER")
+    void delivery() {
+        Order order = OrderFixture.createOrder();
+        doNothing().when(orderApplication).delivery(eq(order.getId().toUuid()), eq(UUID.fromString(customerId())));
+        mockedOwnerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/delivery", order.getId().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void deliveryIfUnauthorized() {
+        mockedCustomerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/delivery", UUID.randomUUID().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatus(HttpStatus.FORBIDDEN)
+                .bodyJson()
+                .hasPathSatisfying("$.success", isFalse());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER")
+    void complete() {
+        Order order = OrderFixture.createOrder();
+        doNothing().when(orderApplication).complete(eq(order.getId().toUuid()), eq(UUID.fromString(customerId())));
+        mockedOwnerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/complete", order.getId().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.success", isTrue());
+    }
+
+    @Test
+    @WithMockUser(roles = "CUSTOMER")
+    void completeIfUnauthorized() {
+        mockedCustomerToken();
+
+        MvcTestResult result = mvcTester.post()
+                .uri("/v1/orders/{orderId}/complete", UUID.randomUUID().toString())
+                .exchange();
+
+        assertThat(result)
+                .hasStatus(HttpStatus.FORBIDDEN)
+                .bodyJson()
+                .hasPathSatisfying("$.success", isFalse());
+    }
+}

--- a/src/test/java/com/sparta/deliveryi/store/presentation/webapi/StoreApiTest.java
+++ b/src/test/java/com/sparta/deliveryi/store/presentation/webapi/StoreApiTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.sparta.deliveryi.AssertThatUtils.*;
+import static com.sparta.deliveryi.MockUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,9 +41,6 @@ import static org.mockito.Mockito.doNothing;
 @Import(DeliveryITestConfiguration.class)
 @AutoConfigureMockMvc
 class StoreApiTest {
-    static final String MANAGER_UUID = "00000000-0000-0000-0000-000000000000";
-    static final String OWNER_UUID = "11111111-1111-1111-1111-111111111111";
-    static final String CUSTOMER_UUID = "22222222-2222-2222-2222-222222222222";
     UUID storeId = UUID.randomUUID();
 
     @Autowired
@@ -60,7 +58,7 @@ class StoreApiTest {
     private StoreRegister storeRegister;
 
     @Test
-    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @WithMockUser(roles = "CUSTOMER")
     void register() throws JsonProcessingException {
         StoreRegisterRequest request = StoreFixture.createStoreRegisterRequest();
         String requestJson = objectMapper.writeValueAsString(request);
@@ -81,7 +79,7 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void updateInfo() throws JsonProcessingException {
         StoreInfoUpdateRequest request = StoreFixture.createStoreUpdateRequest();
         String requestJson = objectMapper.writeValueAsString(request);
@@ -91,10 +89,10 @@ class StoreApiTest {
                 storeApplication.updateInfo(
                         eq(storeId),
                         any(StoreInfoUpdateRequest.class),
-                        eq(UUID.fromString(OWNER_UUID)))
+                        eq(UUID.fromString(ownerId())))
         ).willReturn(store);
 
-        mockedToken(OWNER_UUID, "OWNER");
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.put()
                 .uri("/v1/stores/{storeId}", storeId.toString())
@@ -110,11 +108,11 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @WithMockUser(roles = "CUSTOMER")
     void updateInfoIfUnauthorized() throws JsonProcessingException {
         StoreInfoUpdateRequest request = StoreFixture.createStoreUpdateRequest();
         String requestJson = objectMapper.writeValueAsString(request);
-        mockedToken(CUSTOMER_UUID, "CUSTOMER");
+        mockedCustomerToken();
 
         MvcTestResult result = mvcTester.put()
                 .uri("/v1/stores/{storeId}", storeId.toString())
@@ -129,16 +127,16 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void remove() {
         Store store = StoreFixture.createStore();
         given(
                 storeApplication.remove(
                         eq(storeId),
-                        eq(UUID.fromString(OWNER_UUID))
+                        eq(UUID.fromString(ownerId()))
                 )
         ).willReturn(store);
-        mockedToken(OWNER_UUID, "OWNER");
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.delete()
                 .uri("/v1/stores/{storeId}", storeId.toString())
@@ -152,9 +150,9 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @WithMockUser(roles = "CUSTOMER")
     void removeIfUnauthorized() {
-        mockedToken(CUSTOMER_UUID, "CUSTOMER");
+        mockedCustomerToken();
 
         MvcTestResult result = mvcTester.delete()
                 .uri("/v1/stores/{storeId}", storeId.toString())
@@ -167,13 +165,13 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "manager", roles = "MANAGER")
+    @WithMockUser(roles = "MANAGER")
     void acceptRegisterRequest() {
         doNothing().when(storeRegister).acceptRegisterRequest(
                 eq(storeId),
                 any(UUID.class));
 
-        mockedToken(UUID.randomUUID().toString(), "MANAGER");
+        mockedMangerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/accept", storeId.toString())
@@ -186,9 +184,9 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void acceptRegisterRequestIfUnauthorized() {
-        mockedToken(OWNER_UUID, "OWNER");
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/accept", storeId.toString())
@@ -201,11 +199,11 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "manager", roles = "MANAGER")
+    @WithMockUser(roles = "MANAGER")
     void rejectRegisterRequest() {
         doNothing().when(storeRegister).rejectRegisterRequest(eq(storeId));
 
-        mockedToken(UUID.randomUUID().toString(), "MANAGER");
+        mockedMangerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/reject", storeId.toString())
@@ -218,9 +216,9 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void rejectRegisterRequestIfUnauthorized() {
-        mockedToken(OWNER_UUID, "OWNER");
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/reject", storeId.toString())
@@ -233,10 +231,10 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void open() {
-        doNothing().when(storeApplication).open(eq(storeId), eq(UUID.fromString(OWNER_UUID)));
-        mockedToken(OWNER_UUID, "OWNER");
+        doNothing().when(storeApplication).open(eq(storeId), eq(UUID.fromString(ownerId())));
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/open", storeId.toString())
@@ -249,9 +247,9 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @WithMockUser(roles = "CUSTOMER")
     void openIfUnauthorized() {
-        mockedToken(UUID.randomUUID().toString(), "CUSTOMER");
+        mockedCustomerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/open", storeId.toString())
@@ -264,10 +262,10 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void close() {
-        doNothing().when(storeApplication).close(eq(storeId), eq(UUID.fromString(OWNER_UUID)));
-        mockedToken(OWNER_UUID, "OWNER");
+        doNothing().when(storeApplication).close(eq(storeId), eq(UUID.fromString(ownerId())));
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/close", storeId.toString())
@@ -280,9 +278,9 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @WithMockUser(roles = "CUSTOMER")
     void closeIfUnauthorized() {
-        mockedToken(UUID.randomUUID().toString(), "CUSTOMER");
+        mockedCustomerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/close", storeId.toString())
@@ -295,13 +293,13 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "owner", roles = "OWNER")
+    @WithMockUser(roles = "OWNER")
     void transfer() throws JsonProcessingException {
         StoreTransferRequest request = new StoreTransferRequest(UUID.randomUUID());
         String requestJson = objectMapper.writeValueAsString(request);
 
-        doNothing().when(storeApplication).transfer(eq(storeId), any(UUID.class), eq(UUID.fromString(OWNER_UUID)));
-        mockedToken(OWNER_UUID, "OWNER");
+        doNothing().when(storeApplication).transfer(eq(storeId), any(UUID.class), eq(UUID.fromString(ownerId())));
+        mockedOwnerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/transfer", storeId.toString())
@@ -316,12 +314,12 @@ class StoreApiTest {
     }
 
     @Test
-    @WithMockUser(username = "customer", roles = "CUSTOMER")
+    @WithMockUser(roles = "CUSTOMER")
     void transferIfUnauthorized() throws JsonProcessingException {
         StoreTransferRequest request = new StoreTransferRequest(UUID.randomUUID());
         String requestJson = objectMapper.writeValueAsString(request);
 
-        mockedToken(UUID.randomUUID().toString(), "CUSTOMER");
+        mockedCustomerToken();
 
         MvcTestResult result = mvcTester.post()
                 .uri("/v1/stores/{storeId}/transfer", storeId.toString())
@@ -333,19 +331,6 @@ class StoreApiTest {
                 .hasStatus(HttpStatus.FORBIDDEN)
                 .bodyJson()
                 .hasPathSatisfying("$.success", isFalse());
-    }
-
-    private static void mockedToken(String subject, String role) {
-        Jwt jwt = Jwt.withTokenValue("dummy-token")
-                .header("alg", "none")
-                .subject(subject)
-                .build();
-
-        JwtAuthenticationToken auth = new JwtAuthenticationToken(
-                jwt,
-                List.of(new SimpleGrantedAuthority("ROLE_" + role))
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
 }


### PR DESCRIPTION
## 📝 요약 (Summary)
주문 API 추가 

## 🛠️ 작업 내용 (Details)
1. 주문 등록 api 추가
2. 주문 취소 api 추가
3. 주문 승인/거절 api 추가
4. 조리 완료 api 추가
5. 배달 중 api 추가
6. 주문 완료 api 추가
7. 배달 주소 변경 api 추가

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)